### PR TITLE
Make UI only draw in Viewport Toolbar.

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -29,7 +29,7 @@ from . categories.operators import *
 #UI Panel
 class AM_UI(bpy.types.Panel):
     bl_space_type = 'VIEW_3D'
-    bl_region_type = 'UI'
+    bl_region_type = 'TOOLS'
     bl_label = "Asset Management"
  
     def draw(self, context):


### PR DESCRIPTION
Per Blender's standards the UI should not create duplicate panels in multiple regions, this is confusing for the user and unnecessarily inflates the UI.

Since the Asset Manager is used primarily for adding objects to the scene it belongs in the Toolbar. Whether if should exist in the *Tools* tab or the *Create* tab is debatable.

Ref #3